### PR TITLE
Feat: Rename the tool as "elam"

### DIFF
--- a/check-template-updates.sh
+++ b/check-template-updates.sh
@@ -112,7 +112,7 @@ display_repo_template_updates() {
   if [[ "$repo_template_status" == *"has an update"* ]]
   then
     echo -e "${GREEN_TEXT}You have a repo template update!${DEFAULT_TEXT}"
-    echo -e "To start, run ${BOLD_BLUE_TEXT}.updater/start-template-update.sh repo${DEFAULT_TEXT}"
+    echo -e "To start, run ${BOLD_BLUE_TEXT}.elam/start-template-update.sh repo${DEFAULT_TEXT}"
     echo
   fi
 
@@ -133,7 +133,7 @@ display_parent_template_updates() {
   if [[ "$parent_template_status" == *"has an update"* ]]
   then
     echo -e "${GREEN_TEXT}You have a parent template update!${DEFAULT_TEXT}"
-    echo -e "To start, run ${BOLD_BLUE_TEXT}.updater/start-template-update.sh parent${DEFAULT_TEXT}"
+    echo -e "To start, run ${BOLD_BLUE_TEXT}.elam/start-template-update.sh parent${DEFAULT_TEXT}"
     echo
   fi
 


### PR DESCRIPTION
- Rename the tool as "elam". This is done because this piece of code
  will potentially also handle initializing repos that have been created
  through templates. It will not only stay as a "repo updater". As the
  tool may take a few different directions, a neutral name was elected
  as the new project name.

  Elam is an ancient state that was situated in today's Iran. The tool
  the choice of the name has nothing to do with Iran or the ancient
  civilization and was only chosen because it's a short name that can
  easily be typed out during repo updates.
