### PR TITLE
Fix #7

### DIFF
--- a/init-repo.sh
+++ b/init-repo.sh
@@ -28,13 +28,17 @@ check_vars() {
 
 copy_config_files_to_temp() {
   for config_file in $CONFIG_FILES; do
-    cp "$config_file" "/tmp/$config_file" 2> /dev/null
+    if [ -f "$config_file" ]; then
+      cp "$config_file" "/tmp/$config_file" 
+    fi
   done
 }
 
 move_config_files_to_repo_path() {
   for config_file in $CONFIG_FILES; do
-    cp "$config_file" "/tmp/$config_file" 2> /dev/null
+    if [ -f "/tmp/$config_file" ]; then
+      mv  "/tmp/$config_file" "$config_file"
+    fi
   done
 }
 


### PR DESCRIPTION
- Rewrite functions `copy_config_files_to_temp` and
  `move_config_files_to_repo_path` to fix the issue of the config files
  not being protected. The functions had two issues:
  1- There was no file existence check before the copy operations, this
  coupled with the fact that the errors were sent to null, denied the
  users any chance of monitoring whether anything was broken.
  2- `move_config_files_to_repo_path` had its parameters in the wrong
  order, the function was copying whatever was in the repo path to tmp
  instead of doing the reverse.
  Both issues are resolved with this commit.
